### PR TITLE
Start of Sprint - Enable permissions for Devs

### DIFF
--- a/DevOps/repository_permissions/enable-developers-write-permissions.yml
+++ b/DevOps/repository_permissions/enable-developers-write-permissions.yml
@@ -3,7 +3,7 @@ pr: none
 
 schedules:
 - cron: "0 9 * * Tue"
-  displayName: End-of-Week disable Developer Write Access
+  displayName: Enable Developer Write Access
   branches:
     exclude:
       - 

--- a/DevOps/repository_permissions/enable-developers-write-permissions.yml
+++ b/DevOps/repository_permissions/enable-developers-write-permissions.yml
@@ -18,6 +18,9 @@ steps:
       $header = @{Authorization="Bearer $env:GHAPITOKEN"; Accept="application/vnd.github.inertia-preview+json"}
       if([int]$(Get-Date -UFormat %V) % 2 -eq 0) {
         Invoke-RestMethod -Method 'Put' -Uri $uri -Headers $header -Body '{"permission":"push"}'
+        Write-Host "Sprint Start."
+      } else {
+        Write-Host "This is an automated timed job, successfully running only on even weeks (between sprints). To change permissions mid-sprint (odd week), use Github's Web UI."
       }
   env:
     GHAPITOKEN: $(GHAPIToken)

--- a/DevOps/repository_permissions/enable-developers-write-permissions.yml
+++ b/DevOps/repository_permissions/enable-developers-write-permissions.yml
@@ -16,6 +16,8 @@ steps:
     script: |
       $uri = "https://api.github.com/orgs/PSW-2020-ORG9/teams/developers/repos/PSW-2020-ORG9/HealthcareIS"
       $header = @{Authorization="Bearer $env:GHAPITOKEN"; Accept="application/vnd.github.inertia-preview+json"}
-      Invoke-RestMethod -Method 'Put' -Uri $uri -Headers $header -Body '{"permission":"push"}'
+      if([int]$(Get-Date -UFormat %V) % 2 -eq 0) {
+        Invoke-RestMethod -Method 'Put' -Uri $uri -Headers $header -Body '{"permission":"push"}'
+      }
   env:
     GHAPITOKEN: $(GHAPIToken)

--- a/DevOps/repository_permissions/enable-developers-write-permissions.yml
+++ b/DevOps/repository_permissions/enable-developers-write-permissions.yml
@@ -1,0 +1,21 @@
+trigger: none
+pr: none
+
+schedules:
+- cron: "0 9 * * Tue"
+  displayName: End-of-Week disable Developer Write Access
+  branches:
+    exclude:
+      - 
+  always: true
+
+steps:
+- task: PowerShell@2
+  inputs:
+    targetType: 'inline'
+    script: |
+      $uri = "https://api.github.com/orgs/PSW-2020-ORG9/teams/developers/repos/PSW-2020-ORG9/HealthcareIS"
+      $header = @{Authorization="Bearer $env:GHAPITOKEN"; Accept="application/vnd.github.inertia-preview+json"}
+      Invoke-RestMethod -Method 'Put' -Uri $uri -Headers $header -Body '{"permission":"push"}'
+  env:
+    GHAPITOKEN: $(GHAPIToken)


### PR DESCRIPTION
Automatic (scheduled pipeline) update @PSW-2020-ORG9/developers permissions to **Write** on start of sprint - 10AM Tue UTC+1